### PR TITLE
Implement spore release on left-click

### DIFF
--- a/Assets/Models/Fungus/FungusBody.cs
+++ b/Assets/Models/Fungus/FungusBody.cs
@@ -18,4 +18,26 @@ public class FungusBody : MonoBehaviour
         }
     }
 
+    // Reference to the component handling spore production
+    private FungusReproduction reproduction;
+    private void Awake()
+    {
+        reproduction = GetComponent<FungusReproduction>();
+        if (reproduction == null)
+        {
+            Debug.LogError("FungusReproduction komponens nem található!");
+        }
+    }
+
+    // Public method to trigger spore release
+    public void TriggerSporeRelease()
+    {
+        reproduction.TriggerSporeRelease();
+    }
+    private void OnMouseDown()
+    {
+        // Trigger spore release on left-click.
+        TriggerSporeRelease();
+    }
+
 }

--- a/Assets/Models/Fungus/FungusBody.cs
+++ b/Assets/Models/Fungus/FungusBody.cs
@@ -25,7 +25,7 @@ public class FungusBody : MonoBehaviour
         reproduction = GetComponent<FungusReproduction>();
         if (reproduction == null)
         {
-            Debug.LogError("FungusReproduction komponens nem található!");
+            Debug.LogError("FungusReproduction component not found!");
         }
     }
 

--- a/Assets/Models/Fungus/FungusBody.prefab
+++ b/Assets/Models/Fungus/FungusBody.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 954124029279536945}
   - component: {fileID: -3639606638479547345}
   - component: {fileID: 5417127625134381961}
+  - component: {fileID: -3625614812306017971}
   m_Layer: 0
   m_Name: FungusBody
   m_TagString: Untagged
@@ -122,7 +123,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c3d466a02800344b8b8087f2db6b4a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  height: 5
 --- !u!54 &5417127625134381961
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -150,3 +150,19 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &-3625614812306017971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8331824232130077502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7b3751ea326af44fa3ec9689a6f5c6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sporeCooldown: 5
+  sporeReleaseAmount: 3
+  sporeProductionLimit: 5
+  isAdvanced: 0

--- a/Assets/Models/Fungus/FungusReproduction.cs
+++ b/Assets/Models/Fungus/FungusReproduction.cs
@@ -55,12 +55,22 @@ public class FungusReproduction : MonoBehaviour
         yield return new WaitForSeconds(sporeCooldown);
         canRelease = true;
     }
+    private GridManager gridManager;
+    private void Awake()
+    {
+        gridManager = FindFirstObjectByType<GridManager>();
+        if (gridManager == null) 
+        {
+            Debug.LogError("GridManager not found in the scene!");
+        }
+    }
+
     /// <summary>
     /// Method for spore spreading: spores are distributed to neighboring (or, in advanced cases, more distant) tektons.
     /// </summary>
     private void SpreadSpores(int x, int z)
     {
-        GridManager gridManager = FindFirstObjectByType<GridManager>();
+        
         if (gridManager == null)
         {
             Debug.LogError("GridManager not found in the scene!");

--- a/Assets/Models/Fungus/FungusReproduction.cs
+++ b/Assets/Models/Fungus/FungusReproduction.cs
@@ -78,18 +78,20 @@ public class FungusReproduction : MonoBehaviour
 
                 int newX = x + dx;
                 int newZ = z + dz;
-                if (newX >= 0 && newX < gridManager.width && newZ >= 0 && newZ < gridManager.height)
-                {
-                    GameObject neighborObj = gridManager.GetObject(newX, newZ);
-                    if (neighborObj != null)
-                    {
-                        GridObject neighborGrid = neighborObj.GetComponent<GridObject>();
-                        if (neighborGrid != null)
-                        {
-                            neighborGrid.AddSpores(sporeReleaseAmount);
-                        }
-                    }
-                }
+
+                if (newX < 0 || newX >= gridManager.width || newZ < 0 || newZ >= gridManager.height)
+                    continue;
+
+                GameObject neighborObj = gridManager.GetObject(newX, newZ);
+                if (neighborObj == null)
+                    continue;
+
+                GridObject neighborGrid = neighborObj.GetComponent<GridObject>();
+                if (neighborGrid == null)
+                    continue;
+
+                neighborGrid.AddSpores(sporeReleaseAmount);
+
             }
         }
     }

--- a/Assets/Models/Fungus/FungusReproduction.cs
+++ b/Assets/Models/Fungus/FungusReproduction.cs
@@ -24,6 +24,7 @@ public class FungusReproduction : MonoBehaviour
             {
                 GridObject currentGrid = fungusBody.GridObject;
                 Destroy(fungusBody.gameObject);
+                currentGrid.FungusBody = null;
             }
             return;
         }

--- a/Assets/Models/Fungus/FungusReproduction.cs
+++ b/Assets/Models/Fungus/FungusReproduction.cs
@@ -1,0 +1,95 @@
+using System.Collections;
+using UnityEngine;
+
+public class FungusReproduction : MonoBehaviour
+{
+
+    public float sporeCooldown = 5f;         // Time interval between spore releases.
+    public int sporeReleaseAmount = 3;        // Number of spores released per emission.
+    public int sporeProductionLimit = 2;      // Maximum number of emission attempts.
+    private int currentProductionCount = 0;   // Number of emissions so far.
+
+    [Header("Advanced Fungi Settings")]
+    public bool isAdvanced = false;           // Advanced fungi with a larger spreading radius.
+
+    private bool canRelease = true;
+
+    public void TriggerSporeRelease()
+    {
+        if (currentProductionCount >= sporeProductionLimit)
+        {
+            Debug.Log("The fungus body has reached the spore production limit.");
+            FungusBody fungusBody = GetComponent<FungusBody>();
+            if (fungusBody != null && fungusBody.GridObject != null)
+            {
+                GridObject currentGrid = fungusBody.GridObject;
+                Destroy(fungusBody.gameObject);
+            }
+            return;
+        }
+        if (!canRelease)
+        {
+            Debug.Log("Spore release in progress, please wait for the cooldown.");
+            return;
+        }
+        StartCoroutine(ReleaseSporesCoroutine());
+    }
+    private IEnumerator ReleaseSporesCoroutine()
+    {
+        canRelease = false;
+        currentProductionCount++;
+
+        // Access the associated GridObject through the FungusBody.
+        FungusBody fungusBody = GetComponent<FungusBody>();
+        if (fungusBody != null && fungusBody.GridObject != null)
+        {
+            GridObject currentGrid = fungusBody.GridObject;
+            SpreadSpores(currentGrid.x, currentGrid.z);
+        }
+        else
+        {
+            Debug.LogError("FungusBody or the associated GridObject not found!");
+        }
+
+        yield return new WaitForSeconds(sporeCooldown);
+        canRelease = true;
+    }
+    /// <summary>
+    /// Method for spore spreading: spores are distributed to neighboring (or, in advanced cases, more distant) tektons.
+    /// </summary>
+    private void SpreadSpores(int x, int z)
+    {
+        GridManager gridManager = FindFirstObjectByType<GridManager>();
+        if (gridManager == null)
+        {
+            Debug.LogError("GridManager not found in the scene!");
+            return;
+        }
+
+        int spreadRadius = isAdvanced ? 2 : 1;
+
+        for (int dx = -spreadRadius; dx <= spreadRadius; dx++)
+        {
+            for (int dz = -spreadRadius; dz <= spreadRadius; dz++)
+            {
+                if (dx == 0 && dz == 0)
+                    continue;
+
+                int newX = x + dx;
+                int newZ = z + dz;
+                if (newX >= 0 && newX < gridManager.width && newZ >= 0 && newZ < gridManager.height)
+                {
+                    GameObject neighborObj = gridManager.GetObject(newX, newZ);
+                    if (neighborObj != null)
+                    {
+                        GridObject neighborGrid = neighborObj.GetComponent<GridObject>();
+                        if (neighborGrid != null)
+                        {
+                            neighborGrid.AddSpores(sporeReleaseAmount);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Models/Fungus/FungusReproduction.cs
+++ b/Assets/Models/Fungus/FungusReproduction.cs
@@ -14,6 +14,22 @@ public class FungusReproduction : MonoBehaviour
 
     private bool canRelease = true;
 
+    private GridManager gridManager;
+    private FungusBody fungusBody;
+    private void Awake()
+    {
+        gridManager = FindFirstObjectByType<GridManager>();
+        if (gridManager == null)
+        {
+            Debug.LogError("GridManager not found in the scene!");
+        }
+
+        fungusBody = GetComponent<FungusBody>();
+        if (fungusBody == null)
+        {
+            Debug.LogError("FungusBody component not found!");
+        }
+    }
     public void TriggerSporeRelease()
     {
         if (currentProductionCount >= sporeProductionLimit)
@@ -54,15 +70,6 @@ public class FungusReproduction : MonoBehaviour
 
         yield return new WaitForSeconds(sporeCooldown);
         canRelease = true;
-    }
-    private GridManager gridManager;
-    private void Awake()
-    {
-        gridManager = FindFirstObjectByType<GridManager>();
-        if (gridManager == null) 
-        {
-            Debug.LogError("GridManager not found in the scene!");
-        }
     }
 
     /// <summary>

--- a/Assets/Models/Fungus/FungusReproduction.cs.meta
+++ b/Assets/Models/Fungus/FungusReproduction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7b3751ea326af44fa3ec9689a6f5c6d

--- a/Assets/Models/Tectons/GridObject.cs
+++ b/Assets/Models/Tectons/GridObject.cs
@@ -30,7 +30,7 @@ public class GridObject : MonoBehaviour
     public void AddSpores(int amount)
     {
         sporeCount += amount;
-        Debug.Log($"({x},{z}) tekton spóra száma: {sporeCount}");
+        Debug.Log($"({x},{z}) Number of spores: {sporeCount}");
 
         // If the spore count reaches the threshold and there is no fungus body yet, initiate the growth of a new fungus body.
         if (sporeCount >= sporeThreshold && FungusBody == null)

--- a/Assets/Models/Tectons/GridObject.cs
+++ b/Assets/Models/Tectons/GridObject.cs
@@ -26,7 +26,7 @@ public class GridObject : MonoBehaviour
 
     // Add spores to the tekton, then check if enough spores have accumulated for a new fungus body to grow.
 
-    /// <param name="amount">Hozzáadandó spórák száma</param>
+    /// <param name="amount">Number of spores to be added.</param>
     public void AddSpores(int amount)
     {
         sporeCount += amount;
@@ -38,11 +38,11 @@ public class GridObject : MonoBehaviour
             if (FungusBodyFactory.Instance != null)
             {
                 FungusBodyFactory.Instance.SpawnFungusBody(this);
-                sporeCount = 0; // Reseteljük a spóraszámlálót
+                sporeCount = 0; // Reset the spore counter.
             }
             else
             {
-                Debug.LogError("FungusBodyFactory példány nem található.");
+                Debug.LogError("FungusBodyFactory instance not found.");
             }
         }
     }

--- a/Assets/Models/Tectons/GridObject.cs
+++ b/Assets/Models/Tectons/GridObject.cs
@@ -21,6 +21,32 @@ public class GridObject : MonoBehaviour
         }
     }
 
+    public int sporeCount = 0;
+    public int sporeThreshold = 5;
+
+    // Add spores to the tekton, then check if enough spores have accumulated for a new fungus body to grow.
+
+    /// <param name="amount">Hozzáadandó spórák száma</param>
+    public void AddSpores(int amount)
+    {
+        sporeCount += amount;
+        Debug.Log($"({x},{z}) tekton spóra száma: {sporeCount}");
+
+        // If the spore count reaches the threshold and there is no fungus body yet, initiate the growth of a new fungus body.
+        if (sporeCount >= sporeThreshold && FungusBody == null)
+        {
+            if (FungusBodyFactory.Instance != null)
+            {
+                FungusBodyFactory.Instance.SpawnFungusBody(this);
+                sporeCount = 0; // Reseteljük a spóraszámlálót
+            }
+            else
+            {
+                Debug.LogError("FungusBodyFactory példány nem található.");
+            }
+        }
+    }
+
     public void Awake()
     {
         if (gameObject.GetComponent<Collider>() == null)


### PR DESCRIPTION
Added functionality to trigge spore release when the player left-clicks on a FungusBody. Included cooldown handling and spore spread to neighboring tektons. Integrated checks for spore accumulation to trigger new fungus body growth. The FungusBody now dies after a specified number of spore emissions. Enhanced user feedback with debug messages for spore production status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fungus objects now release spores on left-click, adding an interactive gameplay element.
  - A new system manages spore emission with timing and production limits, influencing how spores spread.
  - Grid elements now accumulate spores and can trigger new fungus growth once a threshold is reached.
  - New variables for spore management have been introduced in grid objects to enhance gameplay dynamics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->