### PR TITLE
Feature/tekton effects 8 edit

### DIFF
--- a/Assets/Scripts/FungalThreads/FungalThread.cs
+++ b/Assets/Scripts/FungalThreads/FungalThread.cs
@@ -130,6 +130,16 @@ public class FungalThread : NetworkBehaviour
         Vector3 startPos = gridObjectA.transform.position;
         Vector3 endPos = gridObjectB.transform.position;
 
+        var tectonAComponent = tectonA.GetComponent<Tecton>();
+        var tectonBComponent = tectonB.GetComponent<Tecton>();
+
+        if ((tectonAComponent != null && tectonAComponent.TectonType == TectonType.ThreadGrowthBoost) ||
+        (tectonBComponent != null && tectonBComponent.TectonType == TectonType.ThreadGrowthBoost))
+        {
+            duration /= 2f; // Grow twice as fast
+            Debug.Log("ThreadGrowthBoost detected. Growth duration halved.");
+        }
+
         float elapsedTime = 0f;
 
         while (elapsedTime < duration)

--- a/Assets/Scripts/FungalThreads/FungalThreadManager.cs
+++ b/Assets/Scripts/FungalThreads/FungalThreadManager.cs
@@ -93,6 +93,31 @@ public class FungalThreadManager : NetworkBehaviour
         {
             Debug.LogWarning("Could not find grid objects to establish logical connection.");
         }
+        if (a.TectonType == TectonType.ThreadDecay || b.TectonType == TectonType.ThreadDecay)
+        {
+            StartThreadDecayTimer(thread);
+        }
+    }
+
+    private void StartThreadDecayTimer(FungalThread thread)
+    {
+        // Generate a random duration between 10 and 30 seconds
+        float decayTime = UnityEngine.Random.Range(10f, 30f);
+
+        // Start a coroutine to destroy the thread after the decay time
+        StartCoroutine(ThreadDecayCoroutine(thread, decayTime));
+
+    }
+
+    private System.Collections.IEnumerator ThreadDecayCoroutine(FungalThread thread, float decayTime)
+    {
+        yield return new WaitForSeconds(decayTime);
+
+        if (thread != null)
+        {
+            Debug.Log($"Thread between {thread.tectonA.name} and {thread.tectonB.name} has decayed after {decayTime} seconds.");
+            RPC_RequestThreadDisconnect(thread.Object.Id);
+        }
     }
 
     [Rpc(RpcSources.StateAuthority, RpcTargets.All)]

--- a/Assets/Scripts/FungalThreads/FungalThreadManager.cs
+++ b/Assets/Scripts/FungalThreads/FungalThreadManager.cs
@@ -1,4 +1,5 @@
 using Fusion;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -37,10 +38,31 @@ public class FungalThreadManager : NetworkBehaviour
         //Log the size of neighbours
         // Debug.LogError($"FungalThreadManagger.CanConnect source: {source.Id} target: {target.Id} neighbours: {source.Neighbors.Count}; {target.Neighbors.Count}");
 
+        // Check if the source and target are neighbors
         if (!source.Neighbors.Contains(target)) return false;
 
+        // Check if the connection already exists
         var key = GetConnectionKey(source, target);
-        return !connections.Contains(key);
+        if(connections.Contains(key))
+        {
+            Debug.LogWarning($"Connection already exists between {source.Id} and {target.Id}");
+            return false;
+        }
+        if ((source.TectonType == TectonType.SingleThreadOnly && HasThread(source)) ||
+            (target.TectonType == TectonType.SingleThreadOnly && HasThread(target)))
+        {
+            Debug.LogWarning($"Cannot connect Thread({source.Id}) and Thread({target.Id}): one of them has a single thread restriction.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool HasThread(Tecton source)
+    {
+        //Check if the source has any threads, with the fungalThreads list
+        return fungalThreads.Any(thread => thread.tectonA == source.GetComponent<NetworkObject>() 
+                                        || thread.tectonB == source.GetComponent<NetworkObject>());
     }
 
     // the spawn method, that will be called only on the server

--- a/Assets/Scripts/Fungus/FungusBody.cs
+++ b/Assets/Scripts/Fungus/FungusBody.cs
@@ -11,7 +11,7 @@ public class FungusBody : NetworkBehaviour
     [Tooltip("Number of spores released per emission.")]
     [SerializeField, Networked] private int sporeReleaseAmount { get; set; } = 3;
     [Tooltip("Maximum number of emission attempts before the fungus body is destroyed.")]
-    [SerializeField, Networked] private int sporeProductionLimit { get; set; } = 2;
+    [SerializeField, Networked] private int sporeProductionLimit { get; set; } = 5;
 
     [Header("Advanced Fungi Settings")]
     [Tooltip("Is this fungus body an advanced type with larger range?")]

--- a/Assets/Scripts/Generation/WorldGeneration.cs
+++ b/Assets/Scripts/Generation/WorldGeneration.cs
@@ -225,6 +225,9 @@ public class WorldGeneration : NetworkBehaviour
                 // Init Tecton component
                 Tecton tectonComponent = tectonObject.GetComponent<Tecton>();
                 tectonComponent.Init(tectonMap[x, z], mapParent);
+
+                // Assign a random TectonType (or use specific logic)
+                tectonComponent.TectonType = (TectonType)Random.Range(0, System.Enum.GetValues(typeof(TectonType)).Length);
             }
         }
         // Not too efficient, but whatever

--- a/Assets/Scripts/Insect/MoveInsect.cs
+++ b/Assets/Scripts/Insect/MoveInsect.cs
@@ -168,7 +168,17 @@ public class MoveInsect : NetworkBehaviour {
             nextGridObject.occupantType = OccupantType.Insect;
 
             Vector3 targetPosition = nextGridObject.transform.position + new Vector3(0, 1f, 0);
-            transform.position = Vector3.MoveTowards(transform.position, targetPosition, speed * Runner.DeltaTime);
+            if(CurrentGridObject != null && CurrentGridObject.parentTecton != null)
+            {
+                if (CurrentGridObject.parentTecton.TectonType == TectonType.InsectEffectZone)
+                {
+                    transform.position = Vector3.MoveTowards(transform.position, targetPosition, speed * Runner.DeltaTime * 2f);
+                }
+                else 
+                {
+                    transform.position = Vector3.MoveTowards(transform.position, targetPosition, speed * Runner.DeltaTime);
+                }
+            }
 
             // If the insect is close to the target position, dequeue the next grid object
             if (Vector3.Distance(transform.position, targetPosition) < 0.01f) {

--- a/Assets/Scripts/Insect/MoveInsect.cs
+++ b/Assets/Scripts/Insect/MoveInsect.cs
@@ -1,5 +1,7 @@
 using Fusion;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.WebSockets;
 using TMPro;
 using UnityEngine;
@@ -59,6 +61,17 @@ public class MoveInsect : NetworkBehaviour {
         if (sporeManager == null)
         {
             Debug.LogError("SporeManager not found in the scene.");
+        }
+        // Wait 0.5 seconds, than Initialize CurrentGridObject
+        Invoke(nameof(InitializeCurrentGridObject), 0.5f);
+    }
+
+    private void InitializeCurrentGridObject()
+    {
+        CurrentGridObject = GridObject.GetGridObjectAt(transform.position);
+        if (CurrentGridObject == null)
+        {
+            Debug.LogError("Failed to initialize CurrentGridObject at the insect's starting position.");
         }
     }
 
@@ -152,7 +165,33 @@ public class MoveInsect : NetworkBehaviour {
         }
         HandleKeyboardInput();
     }
+    private bool CanCrossThread(GridObject current, GridObject next)
+    {
+        if (current == null || next == null)
+        {
+            Debug.LogError("Current or next GridObject is null.");
+            return false;
+        }
 
+        // Find the thread connecting the two GridObjects
+        var thread = FungalThreadManager.Instance.FungalThreads.FirstOrDefault(t =>
+            (t.gridObjectA == current && t.gridObjectB == next) ||
+            (t.gridObjectA == next && t.gridObjectB == current));
+
+        if (thread == null)
+        {
+            //Debug.Log("No thread found between the current and next GridObjects.");
+            return true; // Allow movement if no thread exists
+        }
+
+        if (!thread.IsFullyDeveloped)
+        {
+            Debug.Log("Insect cannot cross the thread because it is not fully developed.");
+            return false;
+        }
+
+        return true;
+    }
     public override void FixedUpdateNetwork() {
         // Only run on server
         if (!HasStateAuthority) return;
@@ -163,6 +202,15 @@ public class MoveInsect : NetworkBehaviour {
         // Move towards the target position
         if (path != null && path.Count > 0) {
             var nextGridObject = path.Peek();
+            if (CurrentGridObject == null)
+            {
+                CurrentGridObject = GridObject.GetGridObjectAt(transform.position);
+            }
+            if (!CanCrossThread(CurrentGridObject, nextGridObject))
+            {
+                Debug.Log("Insect cannot cross the thread.");
+                return;
+            }
 
             // Reserving the next grid object
             nextGridObject.occupantType = OccupantType.Insect;

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -4,8 +4,21 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+public enum TectonType
+{
+    Default,                     // No special effect
+    ThreadGrowthBoost,           // Speeds up FungalThread growth
+    ThreadDecay,                 // FungalThreads disappear over time
+    SingleThreadOnly,            // Only one FungalThread can grow here
+    MultiThreadAllowed,          // Multiple FungalThreads can grow here
+    NoFungusBodyAllowed,         // FungusBody cannot grow here
+    InsectEffectZone,            // Material affects insects (general placeholder)
+    Breakable                    // Tecton can split, severing FungalThreads
+}
 public class Tecton : NetworkBehaviour
 {
+    public TectonType TectonType { get; set; }
+
     public static Transform parent;
 
     public new int Id { get; private set; }

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -123,6 +123,27 @@ public class Tecton : NetworkBehaviour
         int index = UnityEngine.Random.Range(0, tectons.Count);
         return tectons[index];
     }
+    private bool HasFullyDevelopedThread()
+    {
+        if (FungalThreadManager.Instance == null)
+        {
+            Debug.LogError("FungalThreadManager instance is not available.");
+            return false;
+        }
+
+        // Check if any thread in the manager is connected to this Tecton and is fully developed
+        foreach (var thread in FungalThreadManager.Instance.FungalThreads)
+        {
+            if ((thread.tectonA == GetComponent<NetworkObject>() || thread.tectonB == GetComponent<NetworkObject>()) &&
+                thread.IsFullyDeveloped)
+            {
+                return true; // Found a fully developed thread
+            }
+        }
+
+        Debug.Log($"No fully developed thread found for Tecton {Id}.");
+        return false;
+    }
 
     // Add spores to the tekton, then check if enough spores have accumulated for a new fungus body to grow.
     /// <param name="amount">Number of spores to be added.</param>
@@ -142,6 +163,12 @@ public class Tecton : NetworkBehaviour
         // If the spore count reaches the threshold and there is no fungus body yet, initiate the growth of a new fungus body.
         if (Spores.Count() >= SporeThreshold && FungusBody == null)
         {
+            // Check if the Tecton has a fully developed thread
+            if (!HasFullyDevelopedThread())
+            {
+                Debug.LogError($"Cannot spawn FungusBody: No fully developed thread on Tecton {Id}.");
+                return;
+            }
             GridObject spawnGridObject = ChooseRandomEmptyGridObject();
 
             if (spawnGridObject == null)

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -12,7 +12,7 @@ public enum TectonType
     SingleThreadOnly,            // Only one FungalThread can grow here
     NoFungusBodyAllowed,         // FungusBody cannot grow here
     InsectEffectZone,            // Material affects insects (speed up)
-    //Breakable                    // Tecton can split, severing FungalThreads
+    //Breakable                    // TODO Tecton can split, severing FungalThreads
 }
 public class Tecton : NetworkBehaviour
 {

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -10,10 +10,9 @@ public enum TectonType
     ThreadGrowthBoost,           // Speeds up FungalThread growth
     ThreadDecay,                 // FungalThreads disappear over time
     SingleThreadOnly,            // Only one FungalThread can grow here
-    MultiThreadAllowed,          // Multiple FungalThreads can grow here
     NoFungusBodyAllowed,         // FungusBody cannot grow here
     InsectEffectZone,            // Material affects insects (general placeholder)
-    Breakable                    // Tecton can split, severing FungalThreads
+    //Breakable                    // Tecton can split, severing FungalThreads
 }
 public class Tecton : NetworkBehaviour
 {

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -7,11 +7,11 @@ using UnityEngine;
 public enum TectonType
 {
     Default,                     // No special effect
-    ThreadGrowthBoost,           // Speeds up FungalThread growth
+    ThreadGrowthBoost,           // Speeds up FungalThread growth (when there are spores)
     ThreadDecay,                 // FungalThreads disappear over time
     SingleThreadOnly,            // Only one FungalThread can grow here
     NoFungusBodyAllowed,         // FungusBody cannot grow here
-    InsectEffectZone,            // Material affects insects (general placeholder)
+    InsectEffectZone,            // Material affects insects (speed up)
     //Breakable                    // Tecton can split, severing FungalThreads
 }
 public class Tecton : NetworkBehaviour

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -16,6 +16,7 @@ public enum TectonType
 }
 public class Tecton : NetworkBehaviour
 {
+    [Networked]
     public TectonType TectonType { get; set; }
 
     public static Transform parent;

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -151,6 +151,17 @@ public class Tecton : NetworkBehaviour
                 return;
             }
 
+            // Save the selected Tecton into a variable
+            Tecton tecton = spawnGridObject.parentTecton;
+
+            //Check if the selected Tecton has Types that allow fungus body growth
+            if (tecton.TectonType == TectonType.NoFungusBodyAllowed)
+            {
+                // If the Tecton is of type NoFungusBodyAllowed, do not allow fungus body growth
+                Debug.Log("Fungus body cannot grow on this Tecton (TectonType: NoFungusBodyAllowed)");
+                return;
+            }
+
             // Get current tecton's fungus body's player
             PlayerRef player = FungusBody != null ? FungusBody.GetComponent<NetworkObject>().InputAuthority : default;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced animated, networked fungal thread growth between tectons, with visible progress and completion status.
  - Added thread decay for certain thread types, causing automatic disconnection after a random duration.
  - Tectons now have special types affecting thread and fungus body behavior, including thread growth boosts, decay, and restrictions.
  - Tectons are now randomly assigned a special type during world generation.

- **Gameplay Changes**
  - Fungus bodies can only grow on tectons with at least one fully developed thread and are blocked on tectons with specific restrictions.
  - Increased the number of spore emission attempts before a fungus body is destroyed from 2 to 5.
  - Insects are prevented from crossing undeveloped fungal threads and move faster within certain zones.

- **Bug Fixes**
  - Improved insect initialization to ensure accurate grid positioning and movement validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->