### PR TITLE
fix: fungus color

### DIFF
--- a/Assets/Models/Fungus/FungusBodyNew.prefab
+++ b/Assets/Models/Fungus/FungusBodyNew.prefab
@@ -66,9 +66,6 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: e4c74a68e0fab7142b4fe6f4923cc6d1, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 4897090936580891136}
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: e4c74a68e0fab7142b4fe6f4923cc6d1, type: 3}
-      insertIndex: -1
       addedObject: {fileID: 5598494701127772092}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: e4c74a68e0fab7142b4fe6f4923cc6d1, type: 3}
       insertIndex: -1
@@ -91,51 +88,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: e4c74a68e0fab7142b4fe6f4923cc6d1, type: 3}
   m_PrefabInstance: {fileID: 2143288030137170703}
   m_PrefabAsset: {fileID: 0}
---- !u!23 &4897090936580891136
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1260749280442910302}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8712e072fe1a76a4fbcfd0186627cd34, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5598494701127772092
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -173,6 +125,7 @@ MonoBehaviour:
   _sporeReleaseAmount: 3
   _sporeProductionLimit: 5
   _isAdvanced: 0
+  _NetworkedColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!114 &1661144146902683363
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Shader/Dissolve.shadergraph
+++ b/Assets/Resources/Shader/Dissolve.shadergraph
@@ -1475,7 +1475,7 @@
         "a": 0.0
     },
     "isMainColor": false,
-    "m_ColorMode": 0
+    "m_ColorMode": 1
 }
 
 {

--- a/Assets/Scripts/Fungus/FungusBodyFactory.cs
+++ b/Assets/Scripts/Fungus/FungusBodyFactory.cs
@@ -90,7 +90,7 @@ public class FungusBodyFactory : NetworkBehaviour
         fungusBody.Tecton = tecton;
         tecton.FungusBody = fungusBody;
 
-        fungusBody.ChangeColor(PlayerSpawner.Instance.GetPlayerColor(player));
+        fungusBody.NetworkedColor = PlayerSpawner.Instance.GetPlayerColor(player);
 
         // Set the player reference for the fungus body
         fungusBody.PlayerReference = player;


### PR DESCRIPTION
Set NetworkedColor to change color of Fungi. The color is a HDR color, so it can accept RGB values outside [0-1] thus being able to make the fungi brighter to stand out better if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fungus body color is now synchronized across the network, ensuring all players see consistent color changes.

- **Bug Fixes**
  - Color updates on fungus bodies are now reliably displayed for all users during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->