### PR TITLE
Feature/fungal network color

### DIFF
--- a/Assets/Models/Fungus/FungusBodyNew.prefab
+++ b/Assets/Models/Fungus/FungusBodyNew.prefab
@@ -126,6 +126,7 @@ MonoBehaviour:
   _sporeProductionLimit: 5
   _isAdvanced: 0
   _NetworkedColor: {r: 0, g: 0, b: 0, a: 0}
+  _PreviousColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!114 &1661144146902683363
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Models/Fungus/FungusBodyNew.prefab
+++ b/Assets/Models/Fungus/FungusBodyNew.prefab
@@ -126,7 +126,6 @@ MonoBehaviour:
   _sporeProductionLimit: 5
   _isAdvanced: 0
   _NetworkedColor: {r: 0, g: 0, b: 0, a: 0}
-  _PreviousColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!114 &1661144146902683363
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,7 +198,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   outlineMode: 3
-  outlineColor: {r: 1, g: 0, b: 0, a: 1}
+  outlineColor: {r: 0, g: 1, b: 0, a: 1}
   outlineWidth: 6
   precomputeOutline: 1
   bakeKeys:

--- a/Assets/Scripts/FungalThreads/FungalThread.cs
+++ b/Assets/Scripts/FungalThreads/FungalThread.cs
@@ -31,14 +31,24 @@ public class FungalThread : NetworkBehaviour
 
     [SerializeField] private AnimationCurve widthCurve;
 
+    private Material _materialInstance;
+    [Networked, OnChangedRender(nameof(OnColorChanged))] public Color NetworkedColor { get; set; }
+
     private Coroutine growthCoroutine;
 
     [Networked] public PlayerRef PlayerReference { get; set; }
+
+    public void OnColorChanged()
+    {
+        GetComponent<Renderer>().material.SetColor("_Color", NetworkedColor);
+    }
+
     public override void Spawned()
     {
         base.Spawned();
         IsSpawned = true;
-        GetComponent<Renderer>().material.SetColor("_Color", PlayerSpawner.Instance.GetPlayerColor(PlayerReference));
+
+        OnColorChanged();
     }
 
     private void Awake()

--- a/Assets/Scripts/FungalThreads/FungalThread.cs
+++ b/Assets/Scripts/FungalThreads/FungalThread.cs
@@ -38,6 +38,7 @@ public class FungalThread : NetworkBehaviour
     {
         base.Spawned();
         IsSpawned = true;
+        GetComponent<Renderer>().material.SetColor("_Color", PlayerSpawner.Instance.GetPlayerColor(PlayerReference));
     }
 
     private void Awake()
@@ -105,9 +106,9 @@ public class FungalThread : NetworkBehaviour
                 FungusBody fungusBodyB = fungusNetObjB?.GetComponent<FungusBody>();
 
                 // Only validate if we can find at least one FungusBody
-                if ((fungusBodyA == null && fungusBodyB == null) ||
-                    (fungusBodyA != null && fungusBodyA.Object.InputAuthority != PlayerReference &&
-                     fungusBodyB != null && fungusBodyB.Object.InputAuthority != PlayerReference))
+                if (( fungusBodyA == null && fungusBodyB == null ) ||
+                    ( fungusBodyA != null && fungusBodyA.Object.InputAuthority != PlayerReference &&
+                     fungusBodyB != null && fungusBodyB.Object.InputAuthority != PlayerReference ))
                 {
                     Debug.Log("The thread has no valid access to its parent FungusBodies. Despawning thread.");
                     if (Object.HasStateAuthority)

--- a/Assets/Scripts/FungalThreads/FungalThreadManager.cs
+++ b/Assets/Scripts/FungalThreads/FungalThreadManager.cs
@@ -84,6 +84,12 @@ public class FungalThreadManager : NetworkBehaviour
 
         thread.SetTectons(netA, netB);
         thread.PlayerReference = player;
+
+        //Set the color of the thread
+        var renderer = thread.GetComponent<Renderer>();
+        Material mat = renderer.material;
+        mat.SetColor("_Color", PlayerSpawner.Instance.GetPlayerColor(player));
+
         fungalThreads.Add(thread);
 
         // Set logical connection

--- a/Assets/Scripts/FungalThreads/FungalThreadManager.cs
+++ b/Assets/Scripts/FungalThreads/FungalThreadManager.cs
@@ -90,6 +90,8 @@ public class FungalThreadManager : NetworkBehaviour
         Material mat = renderer.material;
         mat.SetColor("_Color", PlayerSpawner.Instance.GetPlayerColor(player));
 
+        thread.NetworkedColor = PlayerSpawner.Instance.GetPlayerColor(player);
+
         fungalThreads.Add(thread);
 
         // Set logical connection

--- a/Assets/Scripts/Fungus/FungusBody.cs
+++ b/Assets/Scripts/Fungus/FungusBody.cs
@@ -41,8 +41,10 @@ public class FungusBody : NetworkBehaviour
         }
     }
 
-    private void Update()
+    public override void Spawned()
     {
+        base.Spawned();
+
         OnColorChanged();
     }
 

--- a/Assets/Scripts/Fungus/FungusBody.cs
+++ b/Assets/Scripts/Fungus/FungusBody.cs
@@ -27,19 +27,25 @@ public class FungusBody : NetworkBehaviour
     [Networked, OnChangedRender(nameof(OnColorChanged))]
     public Color NetworkedColor { get; set; }
 
+    [Networked]
+    public Color PreviousColor { get; set; }
+
     private Material _materialInstance;
 
     private Renderer objectRenderer;
     [Networked] public PlayerRef PlayerReference { get; set; }
 
-    private void Awake() {
+    private void Awake()
+    {
         objectRenderer = GetComponentInChildren<Renderer>();
-        if (objectRenderer != null) {
+        if (objectRenderer != null)
+        {
             _materialInstance = objectRenderer.material;
         }
     }
 
-    private void OnColorChanged() {
+    private void OnColorChanged()
+    {
         _materialInstance.SetColor("_BaseColor", NetworkedColor);
     }
 
@@ -115,6 +121,7 @@ public class FungusBody : NetworkBehaviour
         if (Tecton != null || true) //it should be correctted
         {
             RPC_SpreadSpores();
+            PreviousColor = NetworkedColor;
             NetworkedColor = Color.black;
             canRelease = false;
         }
@@ -133,7 +140,7 @@ public class FungusBody : NetworkBehaviour
         if (sporeCooldownTimer.Expired(Runner))
         {
             // TODO: correct it to set back to original color, instead of default
-            NetworkedColor = Color.white;
+            NetworkedColor = PreviousColor;
             sporeCooldownTimer = TickTimer.None;
             canRelease = true;
         }

--- a/Assets/Scripts/Fungus/FungusBody.cs
+++ b/Assets/Scripts/Fungus/FungusBody.cs
@@ -41,7 +41,12 @@ public class FungusBody : NetworkBehaviour
         }
     }
 
-    private void OnColorChanged()
+    private void Update()
+    {
+        OnColorChanged();
+    }
+
+    public void OnColorChanged()
     {
         _materialInstance.SetColor("_BaseColor", NetworkedColor);
     }

--- a/Assets/Scripts/Fungus/FungusBody.cs
+++ b/Assets/Scripts/Fungus/FungusBody.cs
@@ -27,9 +27,6 @@ public class FungusBody : NetworkBehaviour
     [Networked, OnChangedRender(nameof(OnColorChanged))]
     public Color NetworkedColor { get; set; }
 
-    [Networked]
-    public Color PreviousColor { get; set; }
-
     private Material _materialInstance;
 
     private Renderer objectRenderer;
@@ -121,8 +118,7 @@ public class FungusBody : NetworkBehaviour
         if (Tecton != null || true) //it should be correctted
         {
             RPC_SpreadSpores();
-            PreviousColor = NetworkedColor;
-            NetworkedColor = Color.black;
+            GetComponent<Outline>().OutlineColor = Color.red;
             canRelease = false;
         }
     }
@@ -140,7 +136,7 @@ public class FungusBody : NetworkBehaviour
         if (sporeCooldownTimer.Expired(Runner))
         {
             // TODO: correct it to set back to original color, instead of default
-            NetworkedColor = PreviousColor;
+            GetComponent<Outline>().OutlineColor = Color.green;
             sporeCooldownTimer = TickTimer.None;
             canRelease = true;
         }

--- a/Assets/Scripts/Player/PlayerSpawner.cs
+++ b/Assets/Scripts/Player/PlayerSpawner.cs
@@ -124,6 +124,7 @@ public class PlayerSpawner : NetworkBehaviour, IPlayerJoined
             }
             // Spawn one fungus body for the player
             var fungusBody = fungusBodyFactory.SpawnDefault(player);
+            fungusBody.OnColorChanged();
 
             // Spawn insects near the fungus body
             insectSpawner.SpawnInsectsNearBody(player, fungusBody);
@@ -246,7 +247,7 @@ public class PlayerSpawner : NetworkBehaviour, IPlayerJoined
     [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
     private void RpcSetHudVisibility(bool show)
     {
-        Debug.Log($"RpcSetHudVisibility({show}) called on {(Runner.IsServer ? "Server" : "Client")}");
+        Debug.Log($"RpcSetHudVisibility({show}) called on {( Runner.IsServer ? "Server" : "Client" )}");
         eventChannel?.RaiseShowHideHud(show);
     }
 

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -176,7 +176,7 @@ public class Tecton : NetworkBehaviour
             FungalThread thread = HasFullyDevelopedThread();
             if (thread == null)
             {
-                Debug.LogError($"Cannot spawn FungusBody: No fully developed thread on Tecton {Id}.");
+                Debug.Log($"Cannot spawn FungusBody: No fully developed thread on Tecton {Id}.");
                 return;
             }
             GridObject spawnGridObject = ChooseRandomEmptyGridObject();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Spawned fungal threads now display the color associated with the player who created them.
  - Fungus bodies automatically update their color when spawned.

- **Improvements**
  - Visual feedback for fungus bodies now uses outline colors to indicate state changes (red for spore release, green for reset).
  - Color state management is now handled locally for improved visual clarity.
  - Minor readability improvements in debug logging.

- **Bug Fixes**
  - Logging severity reduced for missing fully developed fungal threads, resulting in less intrusive error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->