### PR TITLE
removed tectontype Singlethreadedonly (commented out)

### DIFF
--- a/Assets/Scripts/FungalThreads/FungalThreadManager.cs
+++ b/Assets/Scripts/FungalThreads/FungalThreadManager.cs
@@ -52,12 +52,12 @@ public class FungalThreadManager : NetworkBehaviour
             Debug.LogWarning($"Connection already exists between {source.Id} and {target.Id}");
             return false;
         }
-        if (( source.TectonType == TectonType.SingleThreadOnly && HasThread(source) ) ||
-            ( target.TectonType == TectonType.SingleThreadOnly && HasThread(target) ))
-        {
-            Debug.LogWarning($"Cannot connect Thread({source.Id}) and Thread({target.Id}): one of them has a single thread restriction.");
-            return false;
-        }
+        //if (( source.TectonType == TectonType.SingleThreadOnly && HasThread(source) ) ||
+        //    ( target.TectonType == TectonType.SingleThreadOnly && HasThread(target) ))
+        //{
+        //    Debug.LogWarning($"Cannot connect Thread({source.Id}) and Thread({target.Id}): one of them has a single thread restriction.");
+        //    return false;
+        //}
 
         return true;
     }

--- a/Assets/Scripts/Tectons/Tecton.cs
+++ b/Assets/Scripts/Tectons/Tecton.cs
@@ -9,7 +9,7 @@ public enum TectonType
     Default,                     // No special effect
     ThreadGrowthBoost,           // Speeds up FungalThread growth (when there are spores)
     ThreadDecay,                 // FungalThreads disappear over time
-    SingleThreadOnly,            // Only one FungalThread can grow here
+    //SingleThreadOnly,            // Only one FungalThread can grow here, this is in the specifikation, but it practically doesnt make sense
     NoFungusBodyAllowed,         // FungusBody cannot grow here
     InsectEffectZone,            // Material affects insects (speed up)
     //Breakable                    // TODO Tecton can split, severing FungalThreads


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed enforcement and references to the "SingleThreadOnly" restriction for connections between objects, allowing more flexible connections.
- **Style**
  - Updated comments to clarify the reasoning behind disabling the "SingleThreadOnly" type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->